### PR TITLE
Compilation error

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ You can also pass the --disable-tests flag to **configure** to avoid building th
 
 To link your own application to libplinkio you can use the following include and library paths after installing it:
 
-    gcc -lplinkio source.c
+    gcc source.c -lplinkio 
 
 If you installed libplinkio to a custom location you need to specify the location of libplinkio:
 


### PR DESCRIPTION
There is a link order problem here. When the GNU linker sees a library, it discards all symbols that it doesn't need. In this case, your library appears before your .c file, so the library is being discarded before the .cpp file is compiled, resulting "undefined reference".