### PR TITLE
Implement api to skip next row while reading bed file

### DIFF
--- a/src/bed.c
+++ b/src/bed.c
@@ -341,6 +341,27 @@ bed_read_row(struct pio_bed_file_t *bed_file, snp_t *buffer)
     return PIO_OK;
 }
 
+pio_status_t
+bed_skip_row(struct pio_bed_file_t *bed_file)
+{
+    size_t row_size_bytes;
+    size_t bytes_read;
+
+    if( feof( bed_file->fp ) != 0 || bed_file->cur_row >= bed_header_num_rows( &bed_file->header ) )
+    {
+        return PIO_END;
+    }
+
+    row_size_bytes = bed_header_row_size( &bed_file->header );
+    if( fseek( bed_file->fp, row_size_bytes, SEEK_CUR ) ) {
+        return PIO_ERROR;
+    }
+
+    bed_file->cur_row++;
+
+    return PIO_OK;
+}
+
 size_t
 bed_row_size(struct pio_bed_file_t *bed_file)
 {

--- a/src/plinkio.c
+++ b/src/plinkio.c
@@ -168,6 +168,12 @@ pio_next_row(struct pio_file_t *plink_file, snp_t *buffer)
     return bed_read_row( &plink_file->bed_file, buffer ); 
 }
 
+pio_status_t
+pio_skip_row(struct pio_file_t *plink_file)
+{
+    return bed_skip_row( &plink_file->bed_file ); 
+}
+
 void
 pio_reset_row(struct pio_file_t *plink_file)
 {

--- a/src/plinkio/bed.h
+++ b/src/plinkio/bed.h
@@ -104,6 +104,17 @@ pio_status_t bed_write_row(struct pio_bed_file_t *bed_file, snp_t *buffer);
 pio_status_t bed_read_row(struct pio_bed_file_t *bed_file, snp_t *buffer);
 
 /**
+ * Skips a single row from the given bed_file.
+ *
+ * @param bed_file Bed file.
+ *
+ * @return PIO_OK if a row could be skipped,
+ *         PIO_END if there are no more rows,
+ *         PIO_ERROR otherwise.
+ */
+pio_status_t bed_skip_row(struct pio_bed_file_t *bed_file);
+
+/**
  * Returns the number of bytes required to store a row from
  * the given bed file.
  *

--- a/src/plinkio/plinkio.h
+++ b/src/plinkio/plinkio.h
@@ -158,6 +158,16 @@ size_t pio_num_loci(struct pio_file_t *plink_file);
 pio_status_t pio_next_row(struct pio_file_t *plink_file, snp_t *buffer);
 
 /**
+ * Skips the next row from the bed file.
+ *
+ * @param plink_file Plink file.
+ *
+ * @return PIO_OK if the row could be read, PIO_END if we are at the
+ *         end of file, PIO_ERROR otherwise.
+ */
+pio_status_t pio_skip_row(struct pio_file_t *plink_file);
+
+/**
  * Moves to the beginning of the file, so that the next call
  * of pio_next_row will return the first row.
  *


### PR DESCRIPTION
This feature dramatically improves performance if users is only interested in reading a very small subset of variants from the bed file.