### PR TITLE
Install header files only for shared library

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,6 +9,7 @@ if( NOT DISABLE_SHARED_LIBRARY )
     target_link_libraries( libplinkio libcsv )
     SET_TARGET_PROPERTIES( libplinkio PROPERTIES OUTPUT_NAME plinkio )
     install( TARGETS libplinkio DESTINATION lib )
+    install( FILES ${HEADERS} DESTINATION include/plinkio )
 endif( )
 
 if( NOT DISABLE_STATIC_LIBRARY ) 
@@ -16,5 +17,3 @@ if( NOT DISABLE_STATIC_LIBRARY )
     target_link_libraries( libplinkio-static libcsv )
     SET_TARGET_PROPERTIES( libplinkio-static PROPERTIES OUTPUT_NAME plinkio )
 endif( )
-
-install( FILES ${HEADERS} DESTINATION include/plinkio )


### PR DESCRIPTION
My scenario is as follows. I'm having libplinkio as a submodule on my project, and I'm building only static version of libplinkio -- which later is statically linked into my binary application. I have an install step in my CMakeLists.txt, and my intent is to only install my binary. That's why I want to exclude libplinkio header files from ``install``. 