### PR TITLE
Fix writing plink files under python3

### DIFF
--- a/py-plinkio/cplinkio.c
+++ b/py-plinkio/cplinkio.c
@@ -77,8 +77,8 @@ static PyTypeObject c_plink_file_prototype =
 
 #define PyInt_FromLong(x) (PyLong_FromLong((x)))
 #define PyInt_AsLong(x) (PyLong_AsLong((x)))
-#define PyString_AsString(x) (PyBytes_AsString(x))
-#define PyString_Size(x) (PyBytes_Size(x))
+#define PyString_AsString(x) (PyUnicode_AsUTF8(x))
+#define PyString_Size(x) (PyObject_Size(x))
 
 #else
 

--- a/py-plinkio/plinkio/plinkfile.py
+++ b/py-plinkio/plinkio/plinkfile.py
@@ -183,6 +183,7 @@ class Sample:
         return "{0} {1} {2} {3}".format( self.fid, self.iid, self.sex, self.affection )
 
 class Locus:
+    __slots__ = ['chromosome', 'name', 'position', 'bp_position', 'allele1', 'allele2']
     def __init__(self, chromosome, name, position, bp_position, allele1, allele2):
         ##
         # Chromosome number starting from 1


### PR DESCRIPTION
I was getting segfaults while trying to use WritablePlinkFile under python3. This pull request redefines `PyString_AsString` and `PyString_Size` to use suitable functions for handling str values under python3. I think this also fixes issue #21. Thanks for the package!

