### PR TITLE
Fix "python setup.py sdist" bug caused by #34

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include src/plinkio/*.h
+include src/plinkio/*.h.in
 include libs/libcsv/inc/*.h
 include py-plinkio/*.h
 include README.rst


### PR DESCRIPTION
Since `include src/plinkio/*.h.in` was not described in "MANIFEST.in",  the source distribution generated by `python setup.py sdist` didn't include "snp_lookup.h.in".
Sorry, this is my fault.